### PR TITLE
Endre til samme form for fortid, nåtid og fremtid

### DIFF
--- a/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
+++ b/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
@@ -2,7 +2,7 @@ import { CustomSanityTyper, Field, SanityTyper } from '../../../typer';
 
 const antallTimer: Field[] = [
   {
-    title: 'antall timer',
+    title: 'Antall timer',
     name: 'antallTimer',
     type: SanityTyper.OBJECT,
     description: '(obligatorisk)',

--- a/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
+++ b/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
@@ -12,8 +12,8 @@ const antallTimer: Field[] = [
     validation: Rule => Rule.required().error('Du må fylle inn spørsmål om antall timer'),
     fields: [
       {
-        title: 'Hvor mange timer i uken har x fått tildelt i barnehagen',
-        name: 'harAntallTimer',
+        title: 'Hvor mange timer i uken har barnet fått tildelt barnehageplass?',
+        name: 'antallTimer',
         type: SanityTyper.OBJECT,
         description: '(obligatorisk)',
         validation: Rule => Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
@@ -32,55 +32,6 @@ const antallTimer: Field[] = [
             validation: Rule =>
               Rule.required().error(
                 'Du må fylle inn en feilmelding for spørsmål om timer i barnehagen',
-              ),
-          },
-        ],
-      },
-      {
-        title: 'Hvor mange timer i uken fikk x tildelt i barnehagen',
-        name: 'fikkTildeltAntallTimer',
-        type: SanityTyper.OBJECT,
-        description: '(obligatorisk)',
-        validation: Rule => Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
-        fields: [
-          {
-            title: 'Spørsmål',
-            name: 'sporsmal',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
-          },
-          {
-            title: 'Feilmelding',
-            name: 'feilmelding',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn en feilmelding for spørsmål om timer i barnehagen',
-              ),
-          },
-        ],
-      },
-      {
-        title: 'Hvor mange timer i uken har x fått tildelt i barnehagen',
-        name: 'fattTildeltAntallTimer',
-        type: SanityTyper.OBJECT,
-        description: '(obligatorisk)',
-        validation: Rule => Rule.required().error('Du må fylle inn spørsmål om tildelte timer'),
-        fields: [
-          {
-            title: 'Spørsmål',
-            name: 'sporsmal',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule => Rule.required().error('Du må fylle inn spørsmål om tildelte timer'),
-          },
-          {
-            title: 'Feilmelding',
-            name: 'feilmelding',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn en feilmelding for spørsmål om tildelte timer',
               ),
           },
         ],

--- a/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
+++ b/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
@@ -2,10 +2,14 @@ import { CustomSanityTyper, Field, SanityTyper } from '../../../typer';
 
 const antallTimer: Field[] = [
   {
-    title: 'Hvor mange timer i uken har barnet fått tildelt barnehageplass?',
+    title: 'antall timer',
     name: 'antallTimer',
     type: SanityTyper.OBJECT,
     description: '(obligatorisk)',
+    options: {
+      collapsable: true,
+      collapsed: true,
+    },
     validation: Rule => Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
     fields: [
       {

--- a/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
+++ b/schemas/felles/modaler/barnehageplassModal/antallTimer.ts
@@ -2,39 +2,26 @@ import { CustomSanityTyper, Field, SanityTyper } from '../../../typer';
 
 const antallTimer: Field[] = [
   {
-    title: 'Antall timer',
+    title: 'Hvor mange timer i uken har barnet fått tildelt barnehageplass?',
     name: 'antallTimer',
     type: SanityTyper.OBJECT,
-    options: {
-      collapsable: true,
-      collapsed: true,
-    },
-    validation: Rule => Rule.required().error('Du må fylle inn spørsmål om antall timer'),
+    description: '(obligatorisk)',
+    validation: Rule => Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
     fields: [
       {
-        title: 'Hvor mange timer i uken har barnet fått tildelt barnehageplass?',
-        name: 'antallTimer',
-        type: SanityTyper.OBJECT,
-        description: '(obligatorisk)',
+        title: 'Spørsmål',
+        name: 'sporsmal',
+        type: CustomSanityTyper.LOCALE_STRING,
         validation: Rule => Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
-        fields: [
-          {
-            title: 'Spørsmål',
-            name: 'sporsmal',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error('Du må fylle inn spørsmål om timer i barnehagen'),
-          },
-          {
-            title: 'Feilmelding',
-            name: 'feilmelding',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn en feilmelding for spørsmål om timer i barnehagen',
-              ),
-          },
-        ],
+      },
+      {
+        title: 'Feilmelding',
+        name: 'feilmelding',
+        type: CustomSanityTyper.LOCALE_STRING,
+        validation: Rule =>
+          Rule.required().error(
+            'Du må fylle inn en feilmelding for spørsmål om timer i barnehagen',
+          ),
       },
     ],
   },

--- a/schemas/felles/modaler/barnehageplassModal/utlandet.ts
+++ b/schemas/felles/modaler/barnehageplassModal/utlandet.ts
@@ -12,8 +12,8 @@ const utlandet: Field[] = [
     validation: Rule => Rule.required().error('Du må fylle inn spørsmål om spørsmål'),
     fields: [
       {
-        title: 'Har x barnehageplass i utlandet',
-        name: 'harBarnehageplassUtlandet',
+        title: 'Er barnehagen utenfor Norge',
+        name: 'barnehageUtlandet',
         type: SanityTyper.OBJECT,
         description: '(obligatorisk)',
         validation: Rule => Rule.required().error('Du må fylle inn spørsmål om barnehageplass'),
@@ -32,60 +32,6 @@ const utlandet: Field[] = [
             validation: Rule =>
               Rule.required().error(
                 'Du må fylle inn en feilmelding for spørsmål om barnehageplass i utlandet',
-              ),
-          },
-        ],
-      },
-      {
-        title: 'Har x hatt barnehageplass i utlandet',
-        name: 'harHattBarnehageplassUtlandet',
-        type: SanityTyper.OBJECT,
-        description: '(obligatorisk)',
-        validation: Rule =>
-          Rule.required().error('Du må fylle inn spørsmål om har hatt barnehageplass i utlandet'),
-        fields: [
-          {
-            title: 'Spørsmål',
-            name: 'sporsmal',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn spørsmål om har hatt barnhageplass i utlandet',
-              ),
-          },
-          {
-            title: 'Feilmelding',
-            name: 'feilmelding',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn en feilmelding for spørsmål om har hatt barnehageplass i utlandet',
-              ),
-          },
-        ],
-      },
-      {
-        title: 'Har x fått tildelt barnehageplass i utlandet',
-        name: 'fattTildeltBarnehageplassUtlandet',
-        type: SanityTyper.OBJECT,
-        description: '(obligatorisk)',
-        validation: Rule =>
-          Rule.required().error('Du må fylle inn spørsmål om tildelt barnehageplass i utlandet'),
-        fields: [
-          {
-            title: 'Spørsmål',
-            name: 'sporsmal',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error('Du må fylle inn spørsmål om tildelt barnhageplass i utlandet'),
-          },
-          {
-            title: 'Feilmelding',
-            name: 'feilmelding',
-            type: CustomSanityTyper.LOCALE_STRING,
-            validation: Rule =>
-              Rule.required().error(
-                'Du må fylle inn en feilmelding for spørsmål om tildelt barnehageplass i utlandet',
               ),
           },
         ],


### PR DESCRIPTION
Har endret så man får samme form på spørsmålet for "Er barnehagen i utlandet" og "antall timer i barnehagen". Dette brekker med det Daniel har lagt inn, så har kopiert de aktuelle tekstene, så jeg kan legge de inn igjen etter denne er merget. 
<img width="570" alt="Skjermbilde 2022-08-23 kl  07 41 00" src="https://user-images.githubusercontent.com/11887409/186079050-8a438b09-418a-4b6b-9e96-a44a8ba86607.png">
<img width="693" alt="Skjermbilde 2022-08-23 kl  07 40 48" src="https://user-images.githubusercontent.com/11887409/186079061-eac41c5c-cc67-4bfd-9b3d-27be00f6edba.png">

