### PR TITLE
Feat: Ny type flettefelt

### DIFF
--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -112,8 +112,7 @@ const customBlock = {
           {
             name: 'flettefelt',
             type: SanityTyper.OBJECT,
-            title: 'Flettefelt',
-            hidden: true, // Deprecated. Skal fjernes. Bruk nye måten
+            title: 'Flettefelt GAMMEL',
             icon: () => 'F',
             components: {
               annotation: FlettefeltGammel,

--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { rgba } from 'polished';
 import { BlockAnnotationProps } from 'sanity';
+import styled from 'styled-components';
 
 import { CustomSanityTyper, EFlettefelt, SanityTyper } from '../typer';
 
@@ -13,7 +14,7 @@ interface FlettefeltProps extends BlockAnnotationProps {
   };
 }
 
-const Flettefelt: React.FC<FlettefeltProps> = props => {
+const FlettefeltGammel: React.FC<FlettefeltProps> = props => {
   return (
     <span
       style={{
@@ -27,6 +28,59 @@ const Flettefelt: React.FC<FlettefeltProps> = props => {
   );
 };
 
+const Flettefelt = styled.span`
+  background-color: rgba(30, 133, 209, 0.2);
+  text-overflow: ellipsis;
+  line-height: normal;
+  white-space: nowrap;
+  max-inline-size: 160px;
+  overflow: hidden;
+  display: inline-block;
+`;
+
+const flettefelter = [
+  { title: 'Barnets navn', value: EFlettefelt.BARN_NAVN },
+  { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
+  { title: 'Ytelse', value: EFlettefelt.YTELSE },
+  { title: 'Ytelse i bestemt form', value: EFlettefelt.YTELSE_BESTEMT_FORM },
+  { title: 'i/utenfor', value: EFlettefelt.I_UTENFOR },
+  {
+    title: 'du / den andre forelderen / omsorgspersonen',
+    value: EFlettefelt.PERSONTYPE,
+  },
+  { title: 'Utlandet/Norge', value: EFlettefelt.UTLANDET_NORGE },
+  { title: 'Antall', value: EFlettefelt.ANTALL },
+  { title: 'Total antall', value: EFlettefelt.TOTAL_ANTALL },
+  { title: 'Klokkeslett', value: EFlettefelt.KLOKKESLETT },
+  { title: 'Dato', value: EFlettefelt.DATO },
+  { title: 'Land', value: EFlettefelt.LAND },
+];
+
+const flettefelt = {
+  name: CustomSanityTyper.FLETTEFELT,
+  type: SanityTyper.OBJECT,
+  fields: [
+    {
+      name: CustomSanityTyper.FLETTEFELT,
+      type: SanityTyper.STRING,
+      options: {
+        list: [...flettefelter],
+      },
+    },
+  ],
+  preview: {
+    select: {
+      flettefelt: CustomSanityTyper.FLETTEFELT,
+    },
+  },
+  components: {
+    preview: (props: { flettefelt: EFlettefelt }) => {
+      const flettefelt = flettefelter.find(flettefelt => flettefelt.value === props.flettefelt);
+      return <Flettefelt>{flettefelt?.title ?? 'Tomt flettefelt'}</Flettefelt>;
+    },
+  },
+};
+
 const customBlock = {
   title: 'Custom block',
   name: CustomSanityTyper.CUSTOM_BLOCK,
@@ -34,6 +88,7 @@ const customBlock = {
   of: [
     {
       type: SanityTyper.BLOCK,
+      of: [flettefelt],
       marks: {
         annotations: [
           {
@@ -58,9 +113,10 @@ const customBlock = {
             name: 'flettefelt',
             type: SanityTyper.OBJECT,
             title: 'Flettefelt',
+            hidden: true, // Deprecated. Skal fjernes. Bruk nye måten
             icon: () => 'F',
             components: {
-              annotation: Flettefelt,
+              annotation: FlettefeltGammel,
             },
             fields: [
               {
@@ -69,23 +125,7 @@ const customBlock = {
                 title: 'Flettefeltverdier',
                 validation: Rule => Rule.required().error('Du må velge gyldig flettefelt!'),
                 options: {
-                  list: [
-                    { title: 'Barnets navn', value: EFlettefelt.BARN_NAVN },
-                    { title: 'Søkers navn', value: EFlettefelt.SØKER_NAVN },
-                    { title: 'Ytelse', value: EFlettefelt.YTELSE },
-                    { title: 'Ytelse i bestemt form', value: EFlettefelt.YTELSE_BESTEMT_FORM },
-                    { title: 'i/utenfor', value: EFlettefelt.I_UTENFOR },
-                    {
-                      title: 'du / den andre forelderen / omsorgspersonen',
-                      value: EFlettefelt.PERSONTYPE,
-                    },
-                    { title: 'Utlandet/Norge', value: EFlettefelt.UTLANDET_NORGE },
-                    { title: 'Antall', value: EFlettefelt.ANTALL },
-                    { title: 'Total antall', value: EFlettefelt.TOTAL_ANTALL },
-                    { title: 'Klokkeslett', value: EFlettefelt.KLOKKESLETT },
-                    { title: 'Dato', value: EFlettefelt.DATO },
-                    { title: 'Land', value: EFlettefelt.LAND },
-                  ],
+                  list: [...flettefelter],
                 },
               },
             ],

--- a/schemas/typer.ts
+++ b/schemas/typer.ts
@@ -46,6 +46,7 @@ export enum CustomSanityTyper {
   CUSTOM_BLOCK = 'customBlock',
   LOCALE_STRING = 'localeString',
   LOCALE_BLOCK = 'localeBlock',
+  FLETTEFELT = 'flettefelt',
 }
 
 export enum DokumentNavn {


### PR DESCRIPTION
Gjør to ting:
- Legger til støtte for ny type flettefelt, som funker likt som i ba-sak og ks-sak
- Legger til "GAMMEL" i tittelen til den gamle varianten, så det er lett å se at denne ikke skal brukes lenger

Sånn ser det ut i studio nå:
![image](https://github.com/navikt/familie-baks-soknad-sanity/assets/25459913/353b58c5-e1d0-41b4-96f2-e8ceeeb8af8e)

Gammel struktur:
_Tekst: Hei, <SØKER_NAVN>! Jeg vil gjerne hjelpe deg med å fylle ut søknaden_
![image](https://github.com/navikt/familie-baks-soknad-sanity/assets/25459913/ac527a89-8be9-401f-bba9-eabc256011ce)

Ny struktur:
_Tekst: Hei, <SØKER_NAVN>!_
![image](https://github.com/navikt/familie-baks-soknad-sanity/assets/25459913/bfbbb315-01dc-48f2-a3f3-af4fb7b4971d)

