### PR TITLE
lag egen gruppe for eslint for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
         - "@sanity/vision"
         - "groq"
         - "@sanity/client"
+    eslint:
+      patterns:
+        - "eslint"
+        - "eslint-*"
+        - "@eslint/*"
+        - "typescript-eslint"
+        - "globals"
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
### 📮 Favro: Dependabot-oppdateringer

### 💰 Hva skal gjøres, og hvorfor?
lag egen gruppe for transitive dependencies og eslint for dependabot

Transitive avhengigheter skaper mye støy og oppdateres som regel via hovedavhengigheten sin så samler de ett sted. Det tillater å fortsatt oppdatere for sikkerhets-oppdateringer osv

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Stemmer antagelsen?

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_


### 👀 Screen shots
_Har det visuelle endret seg? Legg til før- og etterbilder!_
