### PR TITLE
Legg til appId for sanity-cli slik at deploy funker

### DIFF
--- a/sanity.cli.ts
+++ b/sanity.cli.ts
@@ -6,4 +6,7 @@ export default defineCliConfig({
   api: {
     projectId: PROSJEKT_ID,
   },
+  deployment: {
+    appId: '7255495c48b669fef8244ebf',
+  },
 });


### PR DESCRIPTION
### 📮 Favro: N/A

### 💰 Hva skal gjøres, og hvorfor?
Bygg feiler og fikk rapportert en fiks her: https://nav-it.slack.com/archives/CJN0STWB0/p1781787062082519.

Legger til `appId` under `deployment` for sanity CLI, så når den kjører sanity-kommandoer i bygg så finner den riktig app. 

Feilmelding

```
 ›   Error: Cannot run "select" prompt in a non-interactive environment. 
 ›   Provide the required value via flags or environment variables, or run in 
 ›   an interactive terminal.
Error: Process completed with exit code 1.
``` 

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?
Nei

### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
Ikke relevant