### PR TITLE
NAV-27302: Fjern styled-components fra customBlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ dist
 .pnp.*
 
 .sanity/runtime
+.DS_Store

--- a/schemas/felles/customBlock.module.css
+++ b/schemas/felles/customBlock.module.css
@@ -1,0 +1,15 @@
+.flettefeltGammel {
+  background-color: rgba(30, 133, 209, 0.2);
+  color: black;
+  cursor: pointer;
+}
+
+.flettefelt {
+  background-color: rgba(30, 133, 209, 0.2);
+  text-overflow: ellipsis;
+  line-height: normal;
+  white-space: nowrap;
+  max-inline-size: 160px;
+  overflow: hidden;
+  display: inline-block;
+}

--- a/schemas/felles/customBlock.tsx
+++ b/schemas/felles/customBlock.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { rgba } from 'polished';
 import { BlockAnnotationProps } from 'sanity';
-import styled from 'styled-components';
 
 import { CustomSanityTyper, EFlettefelt, SanityTyper } from '../typer';
+
+import styles from './customBlock.module.css';
 
 interface FlettefeltProps extends BlockAnnotationProps {
   value: {
@@ -16,27 +16,15 @@ interface FlettefeltProps extends BlockAnnotationProps {
 
 const FlettefeltGammel: React.FC<FlettefeltProps> = props => {
   return (
-    <span
-      style={{
-        backgroundColor: rgba(30, 133, 209, 0.2),
-        color: 'black',
-        cursor: 'pointer',
-      }}
-    >
+    <span className={styles.flettefeltGammel}>
       {props.value.flettefeltVerdi ? props.value.flettefeltVerdi : props.renderDefault(props)}
     </span>
   );
 };
 
-const Flettefelt = styled.span`
-  background-color: rgba(30, 133, 209, 0.2);
-  text-overflow: ellipsis;
-  line-height: normal;
-  white-space: nowrap;
-  max-inline-size: 160px;
-  overflow: hidden;
-  display: inline-block;
-`;
+const Flettefelt: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <span className={styles.flettefelt}>{children}</span>
+);
 
 const flettefelter = [
   { title: 'Barnets navn', value: EFlettefelt.BARN_NAVN },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
+    "types": ["vite/client"],
     "skipLibCheck": true,
   },
   "esModuleInterop": true


### PR DESCRIPTION
### 📮 Favro:  NAV-27302

### 💰 Hva skal gjøres, og hvorfor?
styled-components er i maintenance mode, og ble kun brukt ett sted i dette repoet: `Flettefelt` i `schemas/felles/customBlock.tsx`.

Stylingen er flyttet til CSS modules (`customBlock.module.css`) og jeg tok med `FlettefeltGammel` i samme slengen.

Underveis dukket det opp to ting verdt å nevne:

**`polished` var en udeklarert avhengighet.** `FlettefeltGammel` importerte `rgba` fra `polished`, men `polished` har aldri stått i `package.json` — den ble kun løst transitivt gjennom styled-components. Den importen er nå borte.

**`styled-components` må bli liggende i `package.json`.** Jeg forsøkte å fjerne den, men `sanity` 5 har den som peer dependency og `yarn build` feiler med `Declared dependency styled-components is not installed`. Vi blir altså ikke kvitt selve pakken før Sanity dropper den, men vår egen bruk er nå borte.

`"types": ["vite/client"]` i `tsconfig.json` gir TypeScript typene for `*.module.css`-importen. Det trengs kun for at `tsc` skal godta importen — Vite bundler CSS-en uansett.